### PR TITLE
Update to set workload version and pin snaps

### DIFF
--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -8,9 +8,10 @@
 # tests.
 
 
+import json
 import unittest
 from subprocess import CalledProcessError
-from unittest.mock import patch
+from unittest.mock import PropertyMock, patch
 
 import ops.testing
 from charms.operator_libs_linux.v1 import snap
@@ -21,6 +22,23 @@ from charm import ParcaOperatorCharm
 
 ops.testing.SIMULATE_CAN_CONNECT = True
 
+SCRAPE_METADATA = {
+    "model": "test-model",
+    "model_uuid": "abcdef",
+    "application": "profiled-app",
+    "charm_name": "test-charm",
+}
+SCRAPE_JOBS = [
+    {
+        "global": {"scrape_interval": "1h"},
+        "rule_files": ["/some/file"],
+        "file_sd_configs": [{"files": "*some-files*"}],
+        "job_name": "my-first-job",
+        "metrics_path": "/one-path",
+        "static_configs": [{"targets": ["*:7000"], "labels": {"some-key": "some-value"}}],
+    },
+]
+
 
 class TestCharm(unittest.TestCase):
     def setUp(self):
@@ -29,15 +47,34 @@ class TestCharm(unittest.TestCase):
         self.harness.begin()
 
     @patch("charm.Parca.install", lambda _: True)
+    @patch("charm.Parca.version", "v0.12.0")
     def test_install_success(self):
         self.harness.charm.on.install.emit()
         self.assertEqual(self.harness.charm.unit.status, MaintenanceStatus("installing parca"))
 
     @patch("parca.Parca.install")
-    def test_install_fail_installing_deps(self, install):
+    def test_install_fail_(self, install):
         install.side_effect = snap.SnapError("failed installing parca")
         self.harness.charm.on.install.emit()
         self.assertEqual(self.harness.charm.unit.status, BlockedStatus("failed installing parca"))
+
+    @patch("charm.Parca.refresh", lambda _: True)
+    def test_upgrade_charm(self):
+        self.harness.charm.on.upgrade_charm.emit()
+        self.assertEqual(self.harness.charm.unit.status, MaintenanceStatus("refreshing parca"))
+
+    @patch("parca.Parca.refresh")
+    def test_upgrade_fail_(self, refresh):
+        refresh.side_effect = snap.SnapError("failed refreshing parca")
+        self.harness.charm.on.upgrade_charm.emit()
+        self.assertEqual(self.harness.charm.unit.status, BlockedStatus("failed refreshing parca"))
+
+    @patch("charm.snap.hold_refresh")
+    @patch("parca.Parca.version", new_callable=PropertyMock(return_value="v0.12.0"))
+    def test_update_status(self, _, hold):
+        self.harness.charm.on.update_status.emit()
+        hold.assert_called_once()
+        self.assertEqual(self.harness.get_workload_version(), "v0.12.0")
 
     @patch("charm.ParcaOperatorCharm._open_port")
     @patch("charm.Parca.start")
@@ -75,3 +112,79 @@ class TestCharm(unittest.TestCase):
         result = self.harness.charm._open_port()
         check_call.assert_called_with(["open-port", "7070/TCP"])
         self.assertFalse(result)
+
+    @patch("charm.Parca.configure")
+    def test_profiling_endpoint_relation(self, _):
+        # Create a relation to an app named "profiled-app"
+        rel_id = self.harness.add_relation("profiling-endpoint", "profiled-app")
+        # Simulate that "profiled-app" has provided the data we're expecting
+        self.harness.update_relation_data(
+            rel_id,
+            "profiled-app",
+            {
+                "scrape_metadata": json.dumps(SCRAPE_METADATA),
+                "scrape_jobs": json.dumps(SCRAPE_JOBS),
+            },
+        )
+        # Add a unit to the relation
+        self.harness.add_relation_unit(rel_id, "profiled-app/0")
+        # Simulate the remote unit adding its details for scraping
+        self.harness.update_relation_data(
+            rel_id,
+            "profiled-app/0",
+            {
+                "prometheus_scrape_unit_address": "1.1.1.1",
+                "prometheus_scrape_unit_name": "profiled-app/0",
+            },
+        )
+        # Taking into account the data provided by the simulated app, we should receive the
+        # following jobs config from the profiling_consumer
+        expected = [
+            {
+                "metrics_path": "/one-path",
+                "static_configs": [
+                    {
+                        "labels": {
+                            "some-key": "some-value",
+                            "juju_model": "test-model",
+                            "juju_model_uuid": "abcdef",
+                            "juju_application": "profiled-app",
+                            "juju_charm": "test-charm",
+                            "juju_unit": "profiled-app/0",
+                        },
+                        "targets": ["1.1.1.1:7000"],
+                    }
+                ],
+                "job_name": "juju_test-model_abcdef_profiled-app_test-charm_prometheus_scrape_my-first-job",
+                "relabel_configs": [
+                    {
+                        "source_labels": [
+                            "juju_model",
+                            "juju_model_uuid",
+                            "juju_application",
+                            "juju_unit",
+                        ],
+                        "separator": "_",
+                        "target_label": "instance",
+                        "regex": "(.*)",
+                    }
+                ],
+            }
+        ]
+        self.assertEqual(self.harness.charm.profiling_consumer.jobs(), expected)
+
+    @patch("charm.Parca.configure")
+    @patch("socket.getfqdn", new=lambda *args: "some.host")
+    def test_metrics_endpoint_relation(self, _):
+        # Create a relation to an app named "prometheus"
+        rel_id = self.harness.add_relation("metrics-endpoint", "prometheus")
+        # Add a prometheus unit
+        self.harness.add_relation_unit(rel_id, "prometheus/0")
+        # Grab the unit data from the relation
+        unit_data = self.harness.get_relation_data(rel_id, self.harness.charm.unit.name)
+        # Ensure that the unit set its targets correctly
+        expected = {
+            "prometheus_scrape_unit_address": "some.host",
+            "prometheus_scrape_unit_name": "parca/0",
+        }
+        self.assertEqual(unit_data, expected)

--- a/tests/unit/test_parca.py
+++ b/tests/unit/test_parca.py
@@ -1,0 +1,37 @@
+# Copyright 2022 Jon Seager
+# See LICENSE file for licensing details.
+
+import unittest
+from unittest.mock import patch
+
+from charms.operator_libs_linux.v1 import snap
+
+from parca import Parca
+
+
+class TestParca(unittest.TestCase):
+    @patch("parca.check_output")
+    @patch("parca.Parca.installed", True)
+    def test_parca_version_next(self, checko):
+        checko.return_value = (
+            b"parca, version v0.12.0-next (commit: e888718c206a5dd63d476849c7349a0352547f1a)\n"
+        )
+        parca = Parca()
+        self.assertEqual(parca.version, "v0.12.0-next+e88871")
+
+    @patch("parca.check_output")
+    @patch("parca.Parca.installed", True)
+    def test_parca_version_tagged(self, checko):
+        checko.return_value = (
+            b"parca, version v0.13.0 (commit: e888718c206a5dd63d476849c7349a0352547f1a)\n"
+        )
+        parca = Parca()
+        self.assertEqual(parca.version, "v0.13.0")
+
+    @patch("parca.Parca.installed", False)
+    def test_parca_version_not_installed(self):
+        try:
+            parca = Parca()
+            parca.version
+        except snap.SnapError as e:
+            self.assertEqual(str(e), "parca snap not installed, cannot fetch version")


### PR DESCRIPTION
- Pin snaps to avoid refreshes happening from under the charm
- Set the workload version appropriately
- Handle the upgrade charm event and allow it to refresh the snap if there are new revisions