### PR TITLE
feat: update storage persistence flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,5 +64,5 @@ $ juju config parca memory-storage-limit=8192
 If you wish to enable the **experimental** storage persistence, you can do as such:
 
 ```bash
-$ juju config parca storage-persist=true
+$ juju config parca enable-persistence=true
 ```

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 options:
-  storage-persist:
+  enable-persistence:
     description: |
       Do not store profiles in memory, persist to disk. Location for persistence is '/var/lib/parca'
     type: boolean
@@ -9,6 +9,6 @@ options:
     description: |
       When storing profiles in memory, configure the in-memory storage limit, specified in MB.
 
-      Does nothing if storage-persist is True.
+      Does nothing if enable-persistence is True.
     type: int
     default: 4096

--- a/lib/charms/parca/v0/parca_config.py
+++ b/lib/charms/parca/v0/parca_config.py
@@ -31,7 +31,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 5
 
 
 DEFAULT_BIN_PATH = "/parca"
@@ -57,14 +57,12 @@ def parca_command_line(
     cmd = [str(bin_path), f"--config-path={config_path}"]
 
     # Render the template files with the correct values
-    if app_config["storage-persist"]:
+    if app_config["enable-persistence"]:
         # Add the correct command line options for disk persistence
-        cmd.append("--storage-in-memory=false")
-        cmd.append("--storage-persist")
+        cmd.append("--enable-persistence")
         cmd.append(f"--storage-path={profile_path}")
     else:
         limit = app_config["memory-storage-limit"] * 1048576
-        cmd.append("--storage-in-memory=true")
         cmd.append(f"--storage-active-memory={limit}")
 
     return " ".join(cmd)

--- a/src/parca.py
+++ b/src/parca.py
@@ -47,11 +47,11 @@ class Parca:
     def configure(self, app_config, scrape_configs=[], restart=True):
         """Configure Parca on the host system. Restart Parca by default."""
         # Configure the snap appropriately
-        if app_config["storage-persist"]:
-            self._snap.set({"storage-persist": "true"})
+        if app_config["enable-persistence"]:
+            self._snap.set({"enable-persistence": "true"})
         else:
             limit = app_config["memory-storage-limit"] * 1048576
-            self._snap.set({"storage-persist": "false", "storage-active-memory": limit})
+            self._snap.set({"enable-persistence": "false", "storage-active-memory": limit})
 
         # Write the config file
         parca_config = ParcaConfig(scrape_configs)

--- a/tests/functional/test_parca.py
+++ b/tests/functional/test_parca.py
@@ -10,7 +10,7 @@ from charms.parca.v0.parca_config import ParcaConfig
 from parca import Parca
 
 DEFAULT_PARCA_CONFIG = {
-    "storage-persist": False,
+    "enable-persistence": False,
     "memory-storage-limit": 1024,
 }
 
@@ -46,12 +46,12 @@ class TestParca(unittest.TestCase):
         self.assertFalse(self.parca.installed)
 
     def test_configure_systemd_storage_persist(self):
-        self.parca.configure({"storage-persist": True})
-        self.assertEqual(self.parca._snap.get("storage-persist"), "true")
+        self.parca.configure({"enable-persistence": True})
+        self.assertEqual(self.parca._snap.get("enable-persistence"), "true")
 
     def test_configure_systemd_storage_in_memory(self):
         self.parca.configure(DEFAULT_PARCA_CONFIG)
-        self.assertEqual(self.parca._snap.get("storage-persist"), "false")
+        self.assertEqual(self.parca._snap.get("enable-persistence"), "false")
         self.assertEqual(self.parca._snap.get("storage-active-memory"), "1073741824")
 
     def test_configure_parca_no_scrape_jobs(self):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -89,7 +89,7 @@ class TestCharm(unittest.TestCase):
     @patch("charm.Parca.configure")
     def test_config_changed(self, configure):
         config = {
-            "storage-persist": False,
+            "enable-persistence": False,
             "memory-storage-limit": 1024,
         }
         self.harness.update_config(config)

--- a/tests/unit/test_parca_config.py
+++ b/tests/unit/test_parca_config.py
@@ -37,51 +37,51 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(parca_config.to_dict(), expected)
 
     def test_parca_command_line_default(self):
-        config = {"storage-persist": False, "memory-storage-limit": 1024}
+        config = {"enable-persistence": False, "memory-storage-limit": 1024}
         cmd = parca_command_line(config)
         self.assertEqual(
             cmd,
-            "/parca --config-path=/etc/parca/parca.yaml --storage-in-memory=true --storage-active-memory=1073741824",
+            "/parca --config-path=/etc/parca/parca.yaml --storage-active-memory=1073741824",
         )
 
     def test_parca_command_line_custom_bin_path(self):
-        config = {"storage-persist": False, "memory-storage-limit": 1024}
+        config = {"enable-persistence": False, "memory-storage-limit": 1024}
         cmd = parca_command_line(config, bin_path="/usr/bin/parca")
         self.assertEqual(
             cmd,
-            "/usr/bin/parca --config-path=/etc/parca/parca.yaml --storage-in-memory=true --storage-active-memory=1073741824",
+            "/usr/bin/parca --config-path=/etc/parca/parca.yaml --storage-active-memory=1073741824",
         )
 
     def test_parca_command_line_custom_config_path(self):
-        config = {"storage-persist": False, "memory-storage-limit": 1024}
+        config = {"enable-persistence": False, "memory-storage-limit": 1024}
         cmd = parca_command_line(config, config_path="/tmp/config.yaml")
         self.assertEqual(
             cmd,
-            "/parca --config-path=/tmp/config.yaml --storage-in-memory=true --storage-active-memory=1073741824",
+            "/parca --config-path=/tmp/config.yaml --storage-active-memory=1073741824",
         )
 
     def test_parca_command_line_memory_limit(self):
-        config = {"storage-persist": False, "memory-storage-limit": 2048}
+        config = {"enable-persistence": False, "memory-storage-limit": 2048}
         cmd = parca_command_line(config)
         self.assertEqual(
             cmd,
-            "/parca --config-path=/etc/parca/parca.yaml --storage-in-memory=true --storage-active-memory=2147483648",
+            "/parca --config-path=/etc/parca/parca.yaml --storage-active-memory=2147483648",
         )
 
     def test_parca_command_line_storage_persist(self):
-        config = {"storage-persist": True, "memory-storage-limit": 2048}
+        config = {"enable-persistence": True, "memory-storage-limit": 2048}
         cmd = parca_command_line(config)
         self.assertEqual(
             cmd,
-            "/parca --config-path=/etc/parca/parca.yaml --storage-in-memory=false --storage-persist --storage-path=/var/lib/parca",
+            "/parca --config-path=/etc/parca/parca.yaml --enable-persistence --storage-path=/var/lib/parca",
         )
 
     def test_parca_command_line_storage_persist_custom_profile_path(self):
-        config = {"storage-persist": True, "memory-storage-limit": 2048}
+        config = {"enable-persistence": True, "memory-storage-limit": 2048}
         cmd = parca_command_line(config, profile_path="/tmp")
         self.assertEqual(
             cmd,
-            "/parca --config-path=/etc/parca/parca.yaml --storage-in-memory=false --storage-persist --storage-path=/tmp",
+            "/parca --config-path=/etc/parca/parca.yaml --enable-persistence --storage-path=/tmp",
         )
 
     def test_parse_version_next(self):


### PR DESCRIPTION
Upstream changes to the flags in the snap [here](https://github.com/parca-dev/parca/pull/1540). Changes reflect the updates to ensure the snap functions correctly. Includes a change to the charm config option name